### PR TITLE
Add GetDeviceProcAddr in Vulkan HAL

### DIFF
--- a/vulkan_hal.cpp
+++ b/vulkan_hal.cpp
@@ -59,12 +59,13 @@ static VkResult EnumerateInstanceExtensionProperties(
                                                              properties);
 }
 
-static PFN_vkVoidFunction GetInstanceProcAddr(VkInstance instance,
-                                              const char* name) {
+
+static PFN_vkVoidFunction GetDeviceProcAddr(VkDevice device, const char* name)
+{
   PFN_vkVoidFunction pfn;
 
   if ((pfn = reinterpret_cast<PFN_vkVoidFunction>(
-           mesa_vulkan::vkGetInstanceProcAddr(instance, name)))) {
+           mesa_vulkan::vkGetDeviceProcAddr(device, name)))) {
     return pfn;
   }
 
@@ -76,6 +77,22 @@ static PFN_vkVoidFunction GetInstanceProcAddr(VkInstance instance,
 
   if (strcmp(name, "vkQueueSignalReleaseImageANDROID") == 0)
     return reinterpret_cast<PFN_vkVoidFunction>(QueueSignalReleaseImageANDROID);
+
+  return nullptr;
+}
+
+
+static PFN_vkVoidFunction GetInstanceProcAddr(VkInstance instance,
+                                              const char* name) {
+  PFN_vkVoidFunction pfn;
+
+  if (strcmp(name, "vkGetDeviceProcAddr") == 0)
+    return reinterpret_cast<PFN_vkVoidFunction>(GetDeviceProcAddr);
+
+  if ((pfn = reinterpret_cast<PFN_vkVoidFunction>(
+           mesa_vulkan::vkGetInstanceProcAddr(instance, name)))) {
+    return pfn;
+  }
 
   return nullptr;
 }

--- a/vulkan_wrapper.cpp
+++ b/vulkan_wrapper.cpp
@@ -59,6 +59,14 @@ bool InitializeVulkan() {
     return false;
   }
 
+  vkGetDeviceProcAddr = reinterpret_cast<PFN_vkGetDeviceProcAddr>(
+      vkGetInstanceProcAddr(NULL, "vkGetDeviceProcAddr"));
+
+  if (vkGetDeviceProcAddr == NULL) {
+    ALOGE("Could not find vkGetDeviceProcAddr symbol. %s", dlerror());
+    return false;
+  }
+
   return true;
 }
 
@@ -69,11 +77,13 @@ void Close() {
     vkEnumerateInstanceExtensionProperties = NULL;
     vkCreateInstance = NULL;
     vkGetInstanceProcAddr = NULL;
+    vkGetDeviceProcAddr = NULL;
   }
 }
 
 PFN_vkCreateInstance vkCreateInstance;
 PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
+PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr;
 PFN_vkEnumerateInstanceExtensionProperties
     vkEnumerateInstanceExtensionProperties;
 }

--- a/vulkan_wrapper.h
+++ b/vulkan_wrapper.h
@@ -25,6 +25,7 @@ bool InitializeVulkan();
 void Close();
 
 extern PFN_vkGetInstanceProcAddr vkGetInstanceProcAddr;
+extern PFN_vkGetDeviceProcAddr vkGetDeviceProcAddr;
 extern PFN_vkCreateInstance vkCreateInstance;
 extern PFN_vkEnumerateInstanceExtensionProperties
     vkEnumerateInstanceExtensionProperties;


### PR DESCRIPTION
These HAL functions vkGetSwapchainGrallocUsageANDROID,
vkAcquireImageANDROID, and vkQueueSignalReleaseImageANDROID should
be handled in vkGetDeviceProcAddr, not vkGetInstanceProcAddr

JIRA: https://01.org/jira/browse/AIA-181
Test: Pass Vulkan dEQP-VK.wsi.android.swapchain.*

Signed-off-by: Xu,Randy <randy.xu@intel.com>