### PR TITLE
wrap vkCreateImage to use vkCreateDmaBufImageINTEL

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -33,7 +33,8 @@ LOCAL_CPPFLAGS := -std=c++1y \
 	-Wno-c99-extensions
 
 LOCAL_C_INCLUDES := \
-	frameworks/native/vulkan/include
+	frameworks/native/vulkan/include \
+	vendor/intel/external/android_ia/mesa/include
 
 LOCAL_SHARED_LIBRARIES := libvulkan liblog libdl libcutils
 


### PR DESCRIPTION
JIRA: None
Test: Pass Vulkan dEQP-VK.wsi.android.swapchain.render.basic
      and see triangle rendered on the screen

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>