### PR TITLE
set swapchain usage flags based on VkImageUsageFlags

### DIFF
--- a/vulkan_hal.cpp
+++ b/vulkan_hal.cpp
@@ -25,10 +25,23 @@
 
 static VkResult GetSwapchainGrallocUsageANDROID(VkDevice /*dev*/,
                                                 VkFormat /*fmt*/,
-                                                VkImageUsageFlags /*usage*/,
+                                                VkImageUsageFlags usage,
                                                 int* grallocUsage) {
-  *grallocUsage =
-      GRALLOC_USAGE_HW_FB | GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_HW_TEXTURE;
+  VkImageUsageFlags usageSrc =
+    VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_SAMPLED_BIT |
+    VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
+
+  VkImageUsageFlags usageDst =
+    VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
+
+  // used for texturing
+  if (usage & usageSrc)
+    *grallocUsage |= GRALLOC_USAGE_HW_TEXTURE;
+
+  // used for rendering
+  if (usage & usageDst)
+    *grallocUsage |= GRALLOC_USAGE_HW_RENDER;
+
   return VK_SUCCESS;
 }
 


### PR DESCRIPTION
swapchain.cpp sets GRALLOC_USAGE_HW_RENDER | GRALLOC_USAGE_HW_TEXTURE
by default, with dEQP tests this seems to result having only
GRALLOC_USAGE_HW_RENDER which depending no platform might mean more
optimal render layout.

JIRA: None
Test: Pass Vulkan dEQP-VK.wsi.android.swapchain.render.basic
      and see triangle rendered on the screen

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>