### PR TITLE
set pNativeFenceFd only if pNativeFenceFd given

### DIFF
--- a/vulkan_hal.cpp
+++ b/vulkan_hal.cpp
@@ -56,7 +56,8 @@ static VkResult AcquireImageANDROID(VkDevice, VkImage /*dev*/,
 static VkResult QueueSignalReleaseImageANDROID(VkQueue /*queue*/,
                                                VkImage /*image*/,
                                                int* pNativeFenceFd) {
-  *pNativeFenceFd = -1;
+  if (pNativeFenceFd)
+    *pNativeFenceFd = -1;
   return VK_SUCCESS;
 }
 


### PR DESCRIPTION
When running tutorial04_first_window no pNativeFenceFd
is given and we crash. Patch makes this program work and
succefully clear window surface on each draw.

JIRA: None
Test: Run tutorial04_first_window example from
      android-vulkan-tutorials succesfully

Signed-off-by: Tapani Pälli <tapani.palli@intel.com>