### PR TITLE
VulkanHal: Solve the VkReplay Failure

### DIFF
--- a/vulkan_hal.cpp
+++ b/vulkan_hal.cpp
@@ -58,6 +58,8 @@ static VkResult AcquireImageANDROID(VkDevice, VkImage /*dev*/,
 }
 
 static VkResult QueueSignalReleaseImageANDROID(VkQueue /*queue*/,
+                                               uint32_t /*waitSemaphoreCount*/,
+                                               const VkSemaphore* /*pWaitSemaphores */,
                                                VkImage /*image*/,
                                                int* pNativeFenceFd) {
   if (pNativeFenceFd)


### PR DESCRIPTION
The failure is due to unmatched QueueSignalReleaseImageANDROID definition in VulkanHAL.
The VkSemaphore* pWaitSemaphores was assigned to -1 by mistake.

JIRA: https://01.org/jira/browse/AIA-399
Test: VkReplay can render the trace file correctly and no regression.